### PR TITLE
Modify height of iframe tag

### DIFF
--- a/frontend/src/components/ConnectionForm.tsx
+++ b/frontend/src/components/ConnectionForm.tsx
@@ -33,7 +33,7 @@ export default function EmbeddedFormModal() {
         <div className="flex-grow overflow-auto mt-2 sm:mt-4">
           <iframe
             src="https://3lhir9ms.paperform.co/?embed=1&takeover=0&inline=1&popup=0&_d=revivalcentermn.org&_in=0"
-            className="w-full h-full border-none min-h-[180vh] md:min-h-[130vh]"
+            className="w-full h-full border-none min-h-[190vh] md:min-h-[130vh]"
             allowFullScreen
           />
         </div>


### PR DESCRIPTION
### PR Description

This pull request modifies the height of the `<iframe>` tag to ensure proper display across different screen sizes, particularly for small and medium devices.

- Added responsive `min-height` using Tailwind CSS for the iframe:
  - `min-h-[190vh]` for small screens instead  of `min-h-[180vh]` 
  
- The `iframe` is embedded within a flex container to allow for proper scrolling behavior on small devices.

### Changes
- Modified `iframe` styling to handle screen size responsiveness.

### Testing
Tested on various device sizes to ensure proper scrollability and display within the modal.

Let me know if you have any suggestions or need further adjustments!
